### PR TITLE
Add fill-ability authorizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ class Post extends Model
      * @var array
      */
     protected $hidden = ['author_comments'];
+    
+    /**
+     * The attributes that should be fillable from requests.
+     *
+     * @var array
+     */
+    protected $fillable = ['content'];
 }
 ```
 
@@ -50,13 +57,25 @@ use App\User;
 class PostPolicy
 {
     /**
-     * Determine if a post author_comments-atrribute can be seen by the user.
+     * Determine if a post author_comments atrribute can be seen and changed by the user.
      *
      * @param  \App\User  $user
      * @param  \App\Post  $post
      * @return bool
      */
     public function seeAuthorComments(User $user, Post $post)
+    {
+        return $user->isAuthor() || $user->created($post);
+    }
+    
+    /**
+     * Determine if the Post content atrribute can be changed by the user.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Post  $post
+     * @return bool
+     */
+    public function changeContent(User $user, Post $post)
     {
         return $user->isAuthor() || $user->created($post);
     }
@@ -82,9 +101,21 @@ class Post extends Model
      * @param  string  $attribute
      * @return string
      */
-    protected function getAttributeAbilityMethod($attribute)
+    protected function getAttributeViewAbilityMethod($attribute)
     {
         return $attribute;
     }
+    
+    /**
+     * Get the method name for the attribute change ability in the model policy.
+     *
+     * @param  string  $attribute
+     * @return string
+     */
+    protected function getAttributeUpdateAbilityMethod($attribute)
+    {
+        return $attribute;
+    }
+
 }
 ```

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -30,6 +30,43 @@ trait AuthorizedAttributes
     }
 
     /**
+     * Get the fillable attributes for the model.
+     *
+     * @return array
+     */
+    public function getFillable()
+    {
+        if (! $policy = Gate::getPolicyFor(self::class)) {
+            return $this->fillable;
+        }
+
+        return array_filter($this->fillable, function ($attribute) use ($policy) {
+            $ability = $this->getAttributeAbilityMethod($attribute);
+
+            if (is_callable([$policy, $ability])) {
+                return ! Gate::denies($ability, $this);
+            }
+
+            return true;
+        });
+    }
+
+    /**
+     * Make the given, typically fillable, attributes non-fillable (but not guarded).
+     *
+     * @param  array|string  $attributes
+     * @return $this
+     */
+    public function makeNonFillable($attributes)
+    {
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+
+        $this->fillable = array_diff($this->fillable, (array) $attributes);
+
+        return $this;
+    }
+
+    /**
      * Get the method name for the attribute visibility ability in the model policy.
      *
      * @param  string  $attribute

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -19,10 +19,10 @@ trait AuthorizedAttributes
         }
 
         return array_filter($this->hidden, function ($attribute) use ($policy) {
-            $ability = $this->getAttributeViewAbilityMethod($attribute);
+            $view_ability = $this->getAttributeViewAbilityMethod($attribute);
 
-            if (is_callable([$policy, $ability])) {
-                return Gate::denies($ability, $this);
+            if (is_callable([$policy, $view_ability])) {
+                return Gate::denies($view_ability, $this);
             }
 
             return true;
@@ -41,12 +41,7 @@ trait AuthorizedAttributes
         }
 
         return array_filter($this->fillable, function ($attribute) use ($policy) {
-            $view_ability = $this->getAttributeViewAbilityMethod($attribute);
             $update_ability = $this->getAttributeUpdateAbilityMethod($attribute);
-
-            if (is_callable([$policy, $view_ability])) {
-                return ! Gate::denies($view_ability, $this);
-            }
 
             if (is_callable([$policy, $update_ability])) {
                 return ! Gate::denies($update_ability, $this);
@@ -54,32 +49,6 @@ trait AuthorizedAttributes
 
             return true;
         });
-    }
-
-    /**
-     * Make the given, typically fillable, attributes non-fillable (but not guarded).
-     *
-     * @param  array|string  $attributes
-     * @return $this
-     */
-    public function makeNonFillable($attributes)
-    {
-        $attributes = is_array($attributes) ? $attributes : func_get_args();
-
-        $this->fillable = array_diff($this->fillable, (array) $attributes);
-
-        return $this;
-    }
-
-    /**
-     * Get the method name for the attribute visibility ability in the model policy.
-     *
-     * @param  string  $attribute
-     * @return string
-     */
-    protected function getAttributeViewAbilityMethod($attribute)
-    {
-        return 'see'.Str::studly($attribute);
     }
 
     /**
@@ -91,6 +60,17 @@ trait AuthorizedAttributes
     protected function getAttributeAbilityMethod($attribute)
     {
         return $this->getAttributeViewAbilityMethod($attribute);
+    }
+
+    /**
+     * Get the method name for the attribute visibility ability in the model policy.
+     *
+     * @param  string  $attribute
+     * @return string
+     */
+    protected function getAttributeViewAbilityMethod($attribute)
+    {
+        return 'see'.Str::studly($attribute);
     }
 
     /**

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -82,6 +82,23 @@ trait AuthorizedAttributes
         return 'see'.Str::studly($attribute);
     }
 
+    /**
+     * Backward-compatibility
+     *
+     * @param $attribute
+     * @return string
+     */
+    protected function getAttributeAbilityMethod($attribute)
+    {
+        return $this->getAttributeViewAbilityMethod($attribute);
+    }
+
+    /**
+     * Get the method name for the ability to update attribute in the model policy.
+     *
+     * @param  string  $attribute
+     * @return string
+     */
     protected function getAttributeUpdateAbilityMethod($attribute)
     {
         return 'change'.Str::studly($attribute);

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -19,7 +19,7 @@ trait AuthorizedAttributes
         }
 
         return array_filter($this->hidden, function ($attribute) use ($policy) {
-            $ability = $this->getAttributeAbilityMethod($attribute);
+            $ability = $this->getAttributeViewAbilityMethod($attribute);
 
             if (is_callable([$policy, $ability])) {
                 return Gate::denies($ability, $this);
@@ -41,10 +41,15 @@ trait AuthorizedAttributes
         }
 
         return array_filter($this->fillable, function ($attribute) use ($policy) {
-            $ability = $this->getAttributeAbilityMethod($attribute);
+            $view_ability = $this->getAttributeViewAbilityMethod($attribute);
+            $update_ability = $this->getAttributeUpdateAbilityMethod($attribute);
 
-            if (is_callable([$policy, $ability])) {
-                return ! Gate::denies($ability, $this);
+            if (is_callable([$policy, $view_ability])) {
+                return ! Gate::denies($view_ability, $this);
+            }
+
+            if (is_callable([$policy, $update_ability])) {
+                return ! Gate::denies($update_ability, $this);
             }
 
             return true;
@@ -72,8 +77,13 @@ trait AuthorizedAttributes
      * @param  string  $attribute
      * @return string
      */
-    protected function getAttributeAbilityMethod($attribute)
+    protected function getAttributeViewAbilityMethod($attribute)
     {
         return 'see'.Str::studly($attribute);
+    }
+
+    protected function getAttributeUpdateAbilityMethod($attribute)
+    {
+        return 'change'.Str::studly($attribute);
     }
 }


### PR DESCRIPTION
Rationale: if I can't see the attribute, why I should I be able to update it?

Making such attributes _guarded_ would perhaps be taking this too far.