### PR TITLE
Ability to disable attribute policy checks at runtime via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ class Post extends Model
      * @var array
      */
     protected $hidden = ['author_comments'];
+    
+    /**
+     * The attributes that should be fillable from requests.
+     *
+     * @var array
+     */
+    protected $fillable = ['content'];
 }
 ```
 
@@ -50,13 +57,25 @@ use App\User;
 class PostPolicy
 {
     /**
-     * Determine if a post author_comments-atrribute can be seen by the user.
+     * Determine if a post author_comments atrribute can be seen and changed by the user.
      *
      * @param  \App\User  $user
      * @param  \App\Post  $post
      * @return bool
      */
     public function seeAuthorComments(User $user, Post $post)
+    {
+        return $user->isAuthor() || $user->created($post);
+    }
+    
+    /**
+     * Determine if the Post content atrribute can be changed by the user.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Post  $post
+     * @return bool
+     */
+    public function changeContent(User $user, Post $post)
     {
         return $user->isAuthor() || $user->created($post);
     }
@@ -82,9 +101,21 @@ class Post extends Model
      * @param  string  $attribute
      * @return string
      */
-    protected function getAttributeAbilityMethod($attribute)
+    protected function getAttributeViewAbilityMethod($attribute)
     {
         return $attribute;
     }
+    
+    /**
+     * Get the method name for the attribute change ability in the model policy.
+     *
+     * @param  string  $attribute
+     * @return string
+     */
+    protected function getAttributeUpdateAbilityMethod($attribute)
+    {
+        return $attribute;
+    }
+
 }
 ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ class PostPolicy
 
 ## Other
 
+### Disable policy checks
+
+E.g.
+
+```config(['authorized-attributes.enabled' => false]); // disable attribute policy checks```
+
 ### Mixin with always hidden attributes
 
 The attributes will be hidden if no policy or ability (method) are found.

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -9,9 +9,9 @@ trait AuthorizedAttributes
 {
 
     private function _isEnabled() {
-        static $is_enabled = null;
+        static $is_enabled;
 
-        if ($is_enabled == null)
+        if (is_null($is_enabled))
             $is_enabled = app('config')->get('authorized-attributes.enabled', true);
 
         return $is_enabled;

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -30,6 +30,43 @@ trait AuthorizedAttributes
     }
 
     /**
+     * Get the fillable attributes for the model.
+     *
+     * @return array
+     */
+    public function getFillable()
+    {
+        if (! $policy = Gate::getPolicyFor(self::class)) {
+            return $this->fillable;
+        }
+
+        return array_filter($this->fillable, function ($attribute) use ($policy) {
+            $ability = $this->getAttributeAbilityMethod($attribute);
+
+            if (is_callable([$policy, $ability])) {
+                return ! Gate::denies($ability, $this);
+            }
+
+            return true;
+        });
+    }
+
+    /**
+     * Make the given, typically fillable, attributes non-fillable (but not guarded).
+     *
+     * @param  array|string  $attributes
+     * @return $this
+     */
+    public function makeNonFillable($attributes)
+    {
+        $attributes = is_array($attributes) ? $attributes : func_get_args();
+
+        $this->fillable = array_diff($this->fillable, (array) $attributes);
+
+        return $this;
+    }
+
+    /**
      * Get the method name for the attribute visibility ability in the model policy.
      *
      * @param  string  $attribute

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -7,6 +7,15 @@ use Illuminate\Support\Str;
 
 trait AuthorizedAttributes
 {
+
+    private function _isEnabled() {
+        static $is_enabled = null;
+
+        if ($is_enabled == null)
+            $is_enabled = app('config')->get('authorized-attributes.enabled', true);
+
+        return $is_enabled;
+    }
     /**
      * Get the hidden attributes for the model.
      *
@@ -14,7 +23,7 @@ trait AuthorizedAttributes
      */
     public function getHidden()
     {
-        if (! $policy = Gate::getPolicyFor(self::class)) {
+        if (! $this->_isEnabled() || ! $policy = Gate::getPolicyFor(self::class)) {
             return $this->hidden;
         }
 
@@ -36,7 +45,7 @@ trait AuthorizedAttributes
      */
     public function getFillable()
     {
-        if (! $policy = Gate::getPolicyFor(self::class)) {
+        if (! $this->_isEnabled() || ! $policy = Gate::getPolicyFor(self::class)) {
             return $this->fillable;
         }
 

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -82,6 +82,23 @@ trait AuthorizedAttributes
         return 'see'.Str::studly($attribute);
     }
 
+    /**
+     * Backward-compatibility
+     *
+     * @param $attribute
+     * @return string
+     */
+    protected function getAttributeAbilityMethod($attribute)
+    {
+        return $this->getAttributeViewAbilityMethod($attribute);
+    }
+
+    /**
+     * Get the method name for the ability to update attribute in the model policy.
+     *
+     * @param  string  $attribute
+     * @return string
+     */
     protected function getAttributeUpdateAbilityMethod($attribute)
     {
         return 'change'.Str::studly($attribute);

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 trait AuthorizedAttributes
 {
 
-    private function _isEnabled() {
+    private function _isAuthorizedAttributesEnabled() {
         static $is_enabled;
 
         if (is_null($is_enabled))
@@ -23,7 +23,7 @@ trait AuthorizedAttributes
      */
     public function getHidden()
     {
-        if (! $this->_isEnabled() || ! $policy = Gate::getPolicyFor(self::class)) {
+        if (! $this->_isAuthorizedAttributesEnabled() || ! $policy = Gate::getPolicyFor(self::class)) {
             return $this->hidden;
         }
 
@@ -45,7 +45,7 @@ trait AuthorizedAttributes
      */
     public function getFillable()
     {
-        if (! $this->_isEnabled() || ! $policy = Gate::getPolicyFor(self::class)) {
+        if (! $this->_isAuthorizedAttributesEnabled() || ! $policy = Gate::getPolicyFor(self::class)) {
             return $this->fillable;
         }
 

--- a/src/AuthorizedAttributes.php
+++ b/src/AuthorizedAttributes.php
@@ -19,7 +19,7 @@ trait AuthorizedAttributes
         }
 
         return array_filter($this->hidden, function ($attribute) use ($policy) {
-            $ability = $this->getAttributeAbilityMethod($attribute);
+            $ability = $this->getAttributeViewAbilityMethod($attribute);
 
             if (is_callable([$policy, $ability])) {
                 return Gate::denies($ability, $this);
@@ -41,10 +41,15 @@ trait AuthorizedAttributes
         }
 
         return array_filter($this->fillable, function ($attribute) use ($policy) {
-            $ability = $this->getAttributeAbilityMethod($attribute);
+            $view_ability = $this->getAttributeViewAbilityMethod($attribute);
+            $update_ability = $this->getAttributeUpdateAbilityMethod($attribute);
 
-            if (is_callable([$policy, $ability])) {
-                return ! Gate::denies($ability, $this);
+            if (is_callable([$policy, $view_ability])) {
+                return ! Gate::denies($view_ability, $this);
+            }
+
+            if (is_callable([$policy, $update_ability])) {
+                return ! Gate::denies($update_ability, $this);
             }
 
             return true;
@@ -72,8 +77,13 @@ trait AuthorizedAttributes
      * @param  string  $attribute
      * @return string
      */
-    protected function getAttributeAbilityMethod($attribute)
+    protected function getAttributeViewAbilityMethod($attribute)
     {
         return 'see'.Str::studly($attribute);
+    }
+
+    protected function getAttributeUpdateAbilityMethod($attribute)
+    {
+        return 'change'.Str::studly($attribute);
     }
 }


### PR DESCRIPTION
Policy checks on large sets of model instance can get slow; this switch may help.